### PR TITLE
Reenable `yay` in `fwcd` flavor

### DIFF
--- a/setup/fwcd
+++ b/setup/fwcd
@@ -22,8 +22,7 @@ packages=(
   rsync
   sudo
   tmux
-  # TODO: There seems to be some issue with https://github.com/fwcd/arch-repo
-  # yay
+  yay
   zsh
 )
 pacman -Syu --noconfirm --needed "${packages[@]}"


### PR DESCRIPTION
This reenables the `yay` package from the custom repo (https://github.com/fwcd/arch-repo).