### PR TITLE
Enable parallel downloads for `fwcd` flavor

### DIFF
--- a/setup/fwcd
+++ b/setup/fwcd
@@ -15,6 +15,9 @@ Server = https://github.com/fwcd/arch-repo-\$arch/releases/latest/download
 SigLevel = Never
 EOF
 
+# Enable parallel downloads
+sed -i 's/#\(ParallelDownloads \)/\1/g' /etc/pacman.conf
+
 # Install useful packages
 packages=(
   avahi


### PR DESCRIPTION
This automatically uncomments the suggested `ParallelDownloads = 5` in `/etc/pacman.conf`.