### PR TITLE
Automatically install `pacman-contrib` into `fwcd` flavor

### DIFF
--- a/setup/fwcd
+++ b/setup/fwcd
@@ -24,6 +24,7 @@ packages=(
   iwd
   man-db
   neovim
+  pacman-contrib
   paru-bin
   python
   rsync


### PR DESCRIPTION
This automatically installs the `pacman-contrib` package into the `fwcd` images, which include some useful helpers such as `pactree`.